### PR TITLE
feat(postgres): add PostgreSQL MCP agent as data connector

### DIFF
--- a/config/postgres_config.yaml
+++ b/config/postgres_config.yaml
@@ -1,0 +1,8 @@
+postgres_instances:
+  - name: local
+    host: "localhost"
+    port: 5432
+    user: "postgres"
+    password: ""
+    dbname: "postgres"
+    sslmode: "disable"

--- a/pkg/agents/postgres/README.md
+++ b/pkg/agents/postgres/README.md
@@ -1,0 +1,170 @@
+# PostgreSQL Agent — SODA Contexture
+
+A **FastMCP-based PostgreSQL data connector** for SODA Contexture.  
+It exposes PostgreSQL databases as MCP tools so the Contexture engine (backed by a **local Ollama model**) can query, analyse, and build enriched OCS context from PostgreSQL data.
+
+Built with the same pattern as `pkg/mcp/server.py` (the Prometheus MCP server).  
+Tools follow the design of established open-source PostgreSQL MCP servers:
+- [`crystaldba/postgres-mcp`](https://github.com/crystaldba/postgres-mcp)
+- [`modelcontextprotocol/servers` — postgres](https://github.com/modelcontextprotocol/servers/tree/main/src/postgres)
+
+---
+
+## Folder Structure
+
+```
+pkg/agents/postgres/
+├── server.py              # FastMCP entry point — all @app.tool() definitions
+├── postgres_connector.py  # psycopg2-based query helpers
+├── mcp_tools.py           # Tool wrapper functions (callable without the server)
+├── tool_registry.py       # TOOLS dict — mirrors mongodb/tool_registry.py
+├── agent.py               # Keyword-based NL query router — mirrors mongodb/agent.py
+├── requirements.txt       # Python dependencies
+└── README.md
+
+config/
+└── postgres_config.yaml   # Connection config (same level as prometheus_config.yaml)
+```
+
+---
+
+## Architecture
+
+```
+Ollama (local LLM)
+      │  NL query → workflow JSON
+      ▼
+client_dynamic.py / client_dynamic_ui.py
+      │  call_tool(name, params)
+      ▼
+server.py  (FastMCP — port 8003)
+      │  @app.tool() handlers
+      ▼
+postgres_connector.py  (psycopg2)
+      │  SQL queries
+      ▼
+PostgreSQL
+```
+
+The flow is identical to how the Prometheus MCP server works (port 8001).  
+The OCS engine fetches context from `/get_ocs_prompt`, the LLM converts the NL query into a list of tool calls, and the FastMCP client executes them against this server.
+
+---
+
+## Available MCP Tools
+
+| Tool | Description |
+|---|---|
+| `pg_check_db_health` | Version, connections, longest query, replication lag — call this first |
+| `pg_list_databases` | All databases with owner, encoding, size |
+| `pg_list_schemas` | User schemas in the connected database |
+| `pg_list_tables` | Tables and views in a given schema |
+| `pg_describe_table` | Columns, types, primary keys, indexes |
+| `pg_execute_query` | Run a SELECT / WITH query, returns rows |
+| `pg_explain_query` | EXPLAIN ANALYZE output for a query |
+| `pg_get_table_stats` | Live rows, dead rows, sizes, vacuum/analyze timestamps |
+| `pg_get_db_stats` | Cache hit ratio, commits, rollbacks, deadlocks from pg_stat_database |
+| `pg_get_slow_queries` | Top slow queries via pg_stat_statements (extension required) |
+
+All tools iterate over every instance in `postgres_config.yaml` and return results keyed by instance name — same pattern as the Prometheus tools returning `*_per_prometheus`.
+
+---
+
+## Configuration
+
+Edit `config/postgres_config.yaml` (created at the project config root):
+
+```yaml
+postgres_instances:
+  - name: local
+    host: "localhost"
+    port: 5432
+    user: "postgres"
+    password: "yourpassword"
+    dbname: "postgres"
+    sslmode: "disable"
+
+  # Add more instances as needed:
+  # - name: analytics
+  #   host: "analytics-db.internal"
+  #   port: 5432
+  #   user: "reader"
+  #   password: "..."
+  #   dbname: "analytics"
+  #   sslmode: "require"
+```
+
+---
+
+## Getting Started
+
+### 1. Install dependencies
+
+```bash
+cd pkg/agents/postgres
+pip install -r requirements.txt
+```
+
+### 2. Configure the connection
+
+```bash
+# Edit the config at project root
+vi ../../config/postgres_config.yaml
+```
+
+### 3. Run the MCP server
+
+**HTTP/SSE transport** (recommended — matches how the Prometheus server runs):
+
+```bash
+uvicorn server:app --port 8003
+```
+
+**stdio transport** (for direct MCP client use):
+
+```bash
+python server.py
+```
+
+### 4. Wire it into the Contexture client
+
+In `config/mcp_server_config.yaml`, add the postgres server URL alongside the Prometheus one:
+
+```yaml
+mcp_server_url: "http://localhost:8001/mcp"        # Prometheus (existing)
+postgres_mcp_url: "http://localhost:8003/mcp"      # PostgreSQL (new)
+```
+
+Then update `pkg/mcp/client_dynamic.py` to connect to the postgres server when postgres tools are needed, or run both servers and route tool calls by name prefix (`pg_*`).
+
+---
+
+## Using as a Standalone Tool (Alternative)
+
+If you prefer to run the upstream open-source server directly instead of this wrapper:
+
+```bash
+# Install crystaldba/postgres-mcp
+pip install postgres-mcp
+
+# Run it (stdio transport, compatible with any MCP client)
+postgres-mcp --db-url "postgresql://postgres:password@localhost:5432/mydb"
+
+# Or with uvx (no install needed)
+uvx postgres-mcp --db-url "postgresql://postgres:password@localhost:5432/mydb"
+```
+
+This provides a subset of the same tools. The `server.py` in this folder adds:
+- Multi-instance support (query multiple PostgreSQL servers at once)
+- Config-file based connection management (consistent with the rest of Contexture)
+- OCS-aligned tool naming and output shape
+
+---
+
+## Adding a New Tool
+
+1. Add a query function to `postgres_connector.py`.
+2. Add a wrapper in `mcp_tools.py`.
+3. Register it in `tool_registry.py`.
+4. Add an `@app.tool()` in `server.py` that iterates `_instances()` and calls the connector.
+5. Optionally add a keyword branch in `agent.py` for direct NL routing.

--- a/pkg/agents/postgres/README.md
+++ b/pkg/agents/postgres/README.md
@@ -15,10 +15,11 @@ Tools follow the design of established open-source PostgreSQL MCP servers:
 ```
 pkg/agents/postgres/
 ├── server.py              # FastMCP entry point — all @app.tool() definitions
-├── postgres_connector.py  # psycopg2-based query helpers
+├── postgres_connector.py  # psycopg2-based query helpers (read-only connections)
 ├── mcp_tools.py           # Tool wrapper functions (callable without the server)
 ├── tool_registry.py       # TOOLS dict — mirrors mongodb/tool_registry.py
 ├── agent.py               # Keyword-based NL query router — mirrors mongodb/agent.py
+├── test_connection.py     # Quick connectivity test — run this first
 ├── requirements.txt       # Python dependencies
 └── README.md
 
@@ -37,10 +38,10 @@ Ollama (local LLM)
 client_dynamic.py / client_dynamic_ui.py
       │  call_tool(name, params)
       ▼
-server.py  (FastMCP — port 8003)
+server.py  (FastMCP — default port 8003)
       │  @app.tool() handlers
       ▼
-postgres_connector.py  (psycopg2)
+postgres_connector.py  (psycopg2, read-only connections)
       │  SQL queries
       ▼
 PostgreSQL
@@ -48,6 +49,8 @@ PostgreSQL
 
 The flow is identical to how the Prometheus MCP server works (port 8001).  
 The OCS engine fetches context from `/get_ocs_prompt`, the LLM converts the NL query into a list of tool calls, and the FastMCP client executes them against this server.
+
+All connections are opened with `default_transaction_read_only=on` — the server never writes to or modifies any data.
 
 ---
 
@@ -61,18 +64,22 @@ The OCS engine fetches context from `/get_ocs_prompt`, the LLM converts the NL q
 | `pg_list_tables` | Tables and views in a given schema |
 | `pg_describe_table` | Columns, types, primary keys, indexes |
 | `pg_execute_query` | Run a SELECT / WITH query, returns rows |
-| `pg_explain_query` | EXPLAIN ANALYZE output for a query |
+| `pg_explain_query` | EXPLAIN (ANALYZE, BUFFERS) output for a SELECT query |
 | `pg_get_table_stats` | Live rows, dead rows, sizes, vacuum/analyze timestamps |
 | `pg_get_db_stats` | Cache hit ratio, commits, rollbacks, deadlocks from pg_stat_database |
-| `pg_get_slow_queries` | Top slow queries via pg_stat_statements (extension required) |
+| `pg_get_slow_queries` | Top slow queries via pg_stat_statements (extension required — see note below) |
 
 All tools iterate over every instance in `postgres_config.yaml` and return results keyed by instance name — same pattern as the Prometheus tools returning `*_per_prometheus`.
+
+> **Note on `pg_get_slow_queries`:** Requires the `pg_stat_statements` extension.  
+> Enable it by adding `pg_stat_statements` to `shared_preload_libraries` in `postgresql.conf` and running `CREATE EXTENSION pg_stat_statements;`. The tool returns an informative error if the extension is absent.  
+> Supports PostgreSQL 12 and 13+ (handles the `total_time` → `total_exec_time` column rename automatically).
 
 ---
 
 ## Configuration
 
-Edit `config/postgres_config.yaml` (created at the project config root):
+Edit `config/postgres_config.yaml` at the project root:
 
 ```yaml
 postgres_instances:
@@ -94,9 +101,13 @@ postgres_instances:
   #   sslmode: "require"
 ```
 
+All fields follow the same pattern as `config/prometheus_config.yaml`.
+
 ---
 
 ## Getting Started
+
+All commands below are run from the `pkg/agents/postgres/` directory.
 
 ### 1. Install dependencies
 
@@ -108,25 +119,53 @@ pip install -r requirements.txt
 ### 2. Configure the connection
 
 ```bash
-# Edit the config at project root
+# Edit the config at the project root (two levels up)
 vi ../../config/postgres_config.yaml
 ```
 
-### 3. Run the MCP server
+### 3. Test the connection
 
-**HTTP/SSE transport** (recommended — matches how the Prometheus server runs):
+Before starting the server, verify the config and connection are working:
 
 ```bash
-uvicorn server:app --port 8003
+python test_connection.py
 ```
 
-**stdio transport** (for direct MCP client use):
+Expected output:
+
+```
+Loading postgres_config.yaml...
+Found 1 instance(s): ['local']
+--------------------------------------------------
+Instance : local
+Host     : localhost:5432
+Database : postgres
+User     : postgres
+Connection: OK
+Databases (3):
+  - mydb     [UTF8]  8192 kB
+  - postgres [UTF8]  8209 kB
+  - template1 [UTF8] 7953 kB
+Schemas   : public
+--------------------------------------------------
+All instances OK.
+```
+
+### 4. Run the MCP server
+
+**stdio transport** (default — matches how FastMCP runs in the rest of Contexture):
 
 ```bash
 python server.py
 ```
 
-### 4. Wire it into the Contexture client
+**SSE/HTTP transport** (for use with `client_dynamic.py` over HTTP):
+
+```bash
+python server.py --transport sse --port 8003
+```
+
+### 5. Wire it into the Contexture client
 
 In `config/mcp_server_config.yaml`, add the postgres server URL alongside the Prometheus one:
 
@@ -139,25 +178,25 @@ Then update `pkg/mcp/client_dynamic.py` to connect to the postgres server when p
 
 ---
 
-## Using as a Standalone Tool (Alternative)
+## Using the Upstream Open-Source Server (Alternative)
 
-If you prefer to run the upstream open-source server directly instead of this wrapper:
+If you prefer to run `crystaldba/postgres-mcp` directly instead of this wrapper:
 
 ```bash
-# Install crystaldba/postgres-mcp
+# Install
 pip install postgres-mcp
 
-# Run it (stdio transport, compatible with any MCP client)
+# Run (stdio transport, compatible with any MCP client)
 postgres-mcp --db-url "postgresql://postgres:password@localhost:5432/mydb"
 
 # Or with uvx (no install needed)
 uvx postgres-mcp --db-url "postgresql://postgres:password@localhost:5432/mydb"
 ```
 
-This provides a subset of the same tools. The `server.py` in this folder adds:
-- Multi-instance support (query multiple PostgreSQL servers at once)
-- Config-file based connection management (consistent with the rest of Contexture)
-- OCS-aligned tool naming and output shape
+The `server.py` in this folder adds on top of that:
+- **Multi-instance support** — query multiple PostgreSQL servers in one call
+- **Config-file based connections** — consistent with the rest of Contexture
+- **OCS-aligned tool naming and output shape**
 
 ---
 

--- a/pkg/agents/postgres/agent.py
+++ b/pkg/agents/postgres/agent.py
@@ -1,0 +1,76 @@
+"""
+Natural-language query router for the PostgreSQL agent.
+
+Maps simple keyword patterns to tool calls — mirrors mongodb/agent.py.
+For richer NL→workflow routing, the main client_dynamic.py / client_dynamic_ui.py
+pipeline is used instead (it talks to the FastMCP server directly via Ollama).
+"""
+
+from tool_registry import TOOLS
+
+
+def process_query(query: str) -> dict:
+    q = query.lower()
+
+    if "health" in q or "status" in q:
+        return TOOLS["check_db_health"]()
+
+    if "slow" in q or "performance" in q or "latency" in q:
+        return TOOLS["get_slow_queries"]()
+
+    if "stat" in q and ("db" in q or "database" in q):
+        return TOOLS["get_db_stats"]()
+
+    if ("stat" in q or "size" in q or "row" in q) and ("table" in q):
+        # expect "stats for table <schema>.<table>" or similar
+        parts = q.split()
+        schema, table = "public", ""
+        for i, p in enumerate(parts):
+            if "." in p:
+                schema, table = p.split(".", 1)
+            elif p == "table" and i + 1 < len(parts):
+                table = parts[i + 1]
+        if table:
+            return TOOLS["get_table_stats"](schema=schema, table=table)
+        return {"message": "Please specify table name, e.g. 'stats for table public.users'"}
+
+    if "describe" in q or "schema of" in q or "columns" in q:
+        parts = q.split()
+        schema, table = "public", ""
+        for p in parts:
+            if "." in p:
+                schema, table = p.split(".", 1)
+        if table:
+            return TOOLS["describe_table"](schema=schema, table=table)
+        return {"message": "Please specify table, e.g. 'describe public.orders'"}
+
+    if "explain" in q:
+        sql = query.strip()
+        for kw in ["explain", "Explain", "EXPLAIN"]:
+            sql = sql.replace(kw, "").strip()
+        return TOOLS["explain_query"](sql=sql) if sql else {"message": "Provide a SQL query to explain."}
+
+    if "select" in q or "query" in q:
+        # Pull out the SQL portion after "query:" or "run:" prefix if present
+        sql = query
+        for prefix in ["query:", "run:", "execute:"]:
+            if prefix in q:
+                sql = query[q.index(prefix) + len(prefix):].strip()
+                break
+        return TOOLS["execute_query"](sql=sql)
+
+    if "table" in q:
+        schema = "public"
+        parts = q.split()
+        for i, p in enumerate(parts):
+            if p in ("schema", "in") and i + 1 < len(parts):
+                schema = parts[i + 1]
+        return TOOLS["list_tables"](schema=schema)
+
+    if "schema" in q:
+        return TOOLS["list_schemas"]()
+
+    if "database" in q or "db" in q:
+        return TOOLS["list_databases"]()
+
+    return {"message": "No matching tool found. Try asking about databases, schemas, tables, health, slow queries, or run a SELECT."}

--- a/pkg/agents/postgres/mcp_tools.py
+++ b/pkg/agents/postgres/mcp_tools.py
@@ -1,0 +1,130 @@
+"""
+MCP tool wrapper functions for the PostgreSQL agent.
+
+Each function corresponds to one @app.tool() in server.py.
+Separated here so they can be called directly (e.g. from agent.py or tests)
+without starting the full FastMCP server.
+"""
+
+from typing import Any, Dict, List, Optional
+from postgres_connector import (
+    get_all_instances,
+    list_databases,
+    list_schemas,
+    list_tables,
+    describe_table,
+    execute_query,
+    explain_query,
+    get_table_stats,
+    get_db_stats,
+    get_slow_queries,
+    check_db_health,
+)
+
+
+def _instances():
+    return get_all_instances()
+
+
+# ── tools ─────────────────────────────────────────────────────────────────────
+
+def list_databases_tool() -> Dict[str, Any]:
+    results = {}
+    for inst in _instances():
+        try:
+            results[inst["name"]] = list_databases(inst)
+        except Exception as e:
+            results[inst["name"]] = {"error": str(e)}
+    return results
+
+
+def list_schemas_tool() -> Dict[str, Any]:
+    results = {}
+    for inst in _instances():
+        try:
+            results[inst["name"]] = list_schemas(inst)
+        except Exception as e:
+            results[inst["name"]] = {"error": str(e)}
+    return results
+
+
+def list_tables_tool(schema: str = "public") -> Dict[str, Any]:
+    results = {}
+    for inst in _instances():
+        try:
+            results[inst["name"]] = list_tables(inst, schema)
+        except Exception as e:
+            results[inst["name"]] = {"error": str(e)}
+    return results
+
+
+def describe_table_tool(schema: str, table: str) -> Dict[str, Any]:
+    results = {}
+    for inst in _instances():
+        try:
+            results[inst["name"]] = describe_table(inst, schema, table)
+        except Exception as e:
+            results[inst["name"]] = {"error": str(e)}
+    return results
+
+
+def execute_query_tool(sql: str, limit: int = 100) -> Dict[str, Any]:
+    results = {}
+    for inst in _instances():
+        try:
+            rows, cols = execute_query(inst, sql, limit)
+            results[inst["name"]] = {"columns": cols, "rows": rows, "row_count": len(rows)}
+        except Exception as e:
+            results[inst["name"]] = {"error": str(e)}
+    return results
+
+
+def explain_query_tool(sql: str) -> Dict[str, Any]:
+    results = {}
+    for inst in _instances():
+        try:
+            results[inst["name"]] = explain_query(inst, sql)
+        except Exception as e:
+            results[inst["name"]] = {"error": str(e)}
+    return results
+
+
+def get_table_stats_tool(schema: str, table: str) -> Dict[str, Any]:
+    results = {}
+    for inst in _instances():
+        try:
+            stats = get_table_stats(inst, schema, table)
+            results[inst["name"]] = stats if stats else {"error": f"Table {schema}.{table} not found in pg_stat_user_tables"}
+        except Exception as e:
+            results[inst["name"]] = {"error": str(e)}
+    return results
+
+
+def get_db_stats_tool() -> Dict[str, Any]:
+    results = {}
+    for inst in _instances():
+        try:
+            results[inst["name"]] = get_db_stats(inst)
+        except Exception as e:
+            results[inst["name"]] = {"error": str(e)}
+    return results
+
+
+def get_slow_queries_tool(min_duration_ms: float = 100.0, limit: int = 10) -> Dict[str, Any]:
+    results = {}
+    for inst in _instances():
+        try:
+            results[inst["name"]] = get_slow_queries(inst, min_duration_ms, limit)
+        except Exception as e:
+            results[inst["name"]] = {"error": str(e)}
+    return results
+
+
+def check_db_health_tool() -> Dict[str, Any]:
+    results = {}
+    for inst in _instances():
+        try:
+            results[inst["name"]] = check_db_health(inst)
+        except Exception as e:
+            results[inst["name"]] = {"error": str(e)}
+    return results

--- a/pkg/agents/postgres/postgres_connector.py
+++ b/pkg/agents/postgres/postgres_connector.py
@@ -1,0 +1,313 @@
+"""
+PostgreSQL connector for SODA Contexture.
+
+Provides low-level query functions used by the MCP tools.
+Connection settings are loaded from config/postgres_config.yaml.
+"""
+
+import os
+import yaml
+import psycopg2
+import psycopg2.extras
+from typing import Any, Dict, List, Optional, Tuple
+
+
+def _load_config() -> List[Dict]:
+    """Load postgres_config.yaml from the repo config directory."""
+    here = os.path.dirname(os.path.abspath(__file__))
+    config_path = os.path.join(here, "..", "..", "..", "config", "postgres_config.yaml")
+    config_path = os.path.normpath(config_path)
+
+    if not os.path.exists(config_path):
+        raise FileNotFoundError(f"postgres_config.yaml not found at {config_path}")
+
+    with open(config_path, "r") as f:
+        cfg = yaml.safe_load(f)
+
+    return cfg.get("postgres_instances", [])
+
+
+def _get_conn(instance: Dict) -> psycopg2.extensions.connection:
+    """Open a psycopg2 connection for a given config instance."""
+    return psycopg2.connect(
+        host=instance.get("host", "localhost"),
+        port=instance.get("port", 5432),
+        user=instance.get("user", "postgres"),
+        password=instance.get("password", ""),
+        dbname=instance.get("dbname", "postgres"),
+        sslmode=instance.get("sslmode", "disable"),
+        cursor_factory=psycopg2.extras.RealDictCursor,
+    )
+
+
+# ── public helpers ────────────────────────────────────────────────────────────
+
+def get_all_instances() -> List[Dict]:
+    return _load_config()
+
+
+def list_databases(instance: Dict) -> List[Dict]:
+    conn = _get_conn(instance)
+    try:
+        with conn.cursor() as cur:
+            cur.execute("""
+                SELECT
+                    d.datname                                              AS name,
+                    pg_catalog.pg_get_userbyid(d.datdba)                  AS owner,
+                    pg_catalog.pg_encoding_to_char(d.encoding)            AS encoding,
+                    d.datcollate                                           AS collation,
+                    pg_catalog.pg_size_pretty(pg_catalog.pg_database_size(d.datname)) AS size
+                FROM   pg_catalog.pg_database d
+                WHERE  d.datistemplate = false
+                ORDER  BY d.datname
+            """)
+            return [dict(r) for r in cur.fetchall()]
+    finally:
+        conn.close()
+
+
+def list_schemas(instance: Dict) -> List[str]:
+    conn = _get_conn(instance)
+    try:
+        with conn.cursor() as cur:
+            cur.execute("""
+                SELECT schema_name
+                FROM   information_schema.schemata
+                WHERE  schema_name NOT IN ('pg_catalog','information_schema','pg_toast')
+                  AND  schema_name NOT LIKE 'pg_temp_%'
+                  AND  schema_name NOT LIKE 'pg_toast_temp_%'
+                ORDER  BY schema_name
+            """)
+            return [r["schema_name"] for r in cur.fetchall()]
+    finally:
+        conn.close()
+
+
+def list_tables(instance: Dict, schema: str = "public") -> List[Dict]:
+    conn = _get_conn(instance)
+    try:
+        with conn.cursor() as cur:
+            cur.execute("""
+                SELECT table_name, table_type
+                FROM   information_schema.tables
+                WHERE  table_schema = %s
+                ORDER  BY table_name
+            """, (schema,))
+            return [dict(r) for r in cur.fetchall()]
+    finally:
+        conn.close()
+
+
+def describe_table(instance: Dict, schema: str, table: str) -> Dict[str, Any]:
+    conn = _get_conn(instance)
+    try:
+        with conn.cursor() as cur:
+            # Columns
+            cur.execute("""
+                SELECT
+                    column_name,
+                    data_type,
+                    character_maximum_length AS max_length,
+                    is_nullable,
+                    column_default
+                FROM information_schema.columns
+                WHERE table_schema = %s AND table_name = %s
+                ORDER BY ordinal_position
+            """, (schema, table))
+            columns = [dict(r) for r in cur.fetchall()]
+
+            # Indexes
+            cur.execute("""
+                SELECT indexname, indexdef
+                FROM   pg_indexes
+                WHERE  schemaname = %s AND tablename = %s
+                ORDER  BY indexname
+            """, (schema, table))
+            indexes = [dict(r) for r in cur.fetchall()]
+
+            # Primary key
+            cur.execute("""
+                SELECT kcu.column_name
+                FROM   information_schema.table_constraints tc
+                JOIN   information_schema.key_column_usage kcu
+                       ON tc.constraint_name = kcu.constraint_name
+                       AND tc.table_schema   = kcu.table_schema
+                WHERE  tc.constraint_type = 'PRIMARY KEY'
+                  AND  tc.table_schema    = %s
+                  AND  tc.table_name      = %s
+                ORDER  BY kcu.ordinal_position
+            """, (schema, table))
+            primary_keys = [r["column_name"] for r in cur.fetchall()]
+
+            return {
+                "schema": schema,
+                "table": table,
+                "columns": columns,
+                "primary_keys": primary_keys,
+                "indexes": indexes,
+            }
+    finally:
+        conn.close()
+
+
+def execute_query(instance: Dict, sql: str, limit: int = 100) -> Tuple[List[Dict], List[str]]:
+    """Run a read-only SELECT query, returning (rows, column_names)."""
+    normalized = sql.strip().upper()
+    if not (normalized.startswith("SELECT") or normalized.startswith("WITH")):
+        raise ValueError("Only SELECT / WITH queries are allowed via execute_query.")
+
+    conn = _get_conn(instance)
+    try:
+        with conn.cursor() as cur:
+            cur.execute(sql)
+            rows = cur.fetchmany(limit)
+            col_names = [desc[0] for desc in cur.description] if cur.description else []
+            return [dict(r) for r in rows], col_names
+    finally:
+        conn.close()
+
+
+def explain_query(instance: Dict, sql: str) -> List[str]:
+    """Return EXPLAIN ANALYZE output for a query."""
+    conn = _get_conn(instance)
+    try:
+        with conn.cursor() as cur:
+            cur.execute(f"EXPLAIN ANALYZE {sql}")
+            return [row[0] for row in cur.fetchall()]
+    finally:
+        conn.close()
+
+
+def get_table_stats(instance: Dict, schema: str, table: str) -> Optional[Dict]:
+    """Return pg_stat_user_tables row for a specific table."""
+    conn = _get_conn(instance)
+    try:
+        with conn.cursor() as cur:
+            cur.execute("""
+                SELECT
+                    n_live_tup                                                         AS live_rows,
+                    n_dead_tup                                                         AS dead_rows,
+                    pg_size_pretty(pg_total_relation_size(
+                        (quote_ident(schemaname)||'.'||quote_ident(relname))::regclass)) AS total_size,
+                    pg_size_pretty(pg_indexes_size(
+                        (quote_ident(schemaname)||'.'||quote_ident(relname))::regclass)) AS index_size,
+                    COALESCE(last_vacuum::text,  '-')                                  AS last_vacuum,
+                    COALESCE(last_analyze::text, '-')                                  AS last_analyze,
+                    COALESCE(last_autovacuum::text,  '-')                              AS last_autovacuum,
+                    COALESCE(last_autoanalyze::text, '-')                              AS last_autoanalyze
+                FROM pg_stat_user_tables
+                WHERE schemaname = %s AND relname = %s
+            """, (schema, table))
+            row = cur.fetchone()
+            return dict(row) if row else None
+    finally:
+        conn.close()
+
+
+def get_db_stats(instance: Dict) -> Dict[str, Any]:
+    """Return pg_stat_database for the connected database."""
+    conn = _get_conn(instance)
+    try:
+        with conn.cursor() as cur:
+            cur.execute("""
+                SELECT
+                    datname,
+                    numbackends                                          AS active_connections,
+                    xact_commit                                          AS commits,
+                    xact_rollback                                        AS rollbacks,
+                    blks_read                                            AS disk_blocks_read,
+                    blks_hit                                             AS buffer_cache_hits,
+                    CASE WHEN (blks_hit + blks_read) > 0
+                         THEN round(100.0 * blks_hit / (blks_hit + blks_read), 2)
+                         ELSE 0 END                                      AS cache_hit_ratio_pct,
+                    tup_returned                                         AS rows_returned,
+                    tup_fetched                                          AS rows_fetched,
+                    tup_inserted                                         AS rows_inserted,
+                    tup_updated                                          AS rows_updated,
+                    tup_deleted                                          AS rows_deleted,
+                    deadlocks
+                FROM pg_stat_database
+                WHERE datname = current_database()
+            """)
+            row = cur.fetchone()
+            return dict(row) if row else {}
+    finally:
+        conn.close()
+
+
+def get_slow_queries(instance: Dict, min_duration_ms: float = 100.0, limit: int = 10) -> List[Dict]:
+    """
+    Return top slow queries from pg_stat_statements.
+    Requires the pg_stat_statements extension to be enabled.
+    """
+    conn = _get_conn(instance)
+    try:
+        with conn.cursor() as cur:
+            # Check extension exists first
+            cur.execute("""
+                SELECT 1 FROM pg_extension WHERE extname = 'pg_stat_statements'
+            """)
+            if not cur.fetchone():
+                return [{"error": "pg_stat_statements extension is not enabled on this server."}]
+
+            cur.execute("""
+                SELECT
+                    left(query, 200)                             AS query_preview,
+                    calls,
+                    round(total_exec_time::numeric, 2)           AS total_exec_ms,
+                    round(mean_exec_time::numeric,  2)           AS mean_exec_ms,
+                    round(stddev_exec_time::numeric, 2)          AS stddev_exec_ms,
+                    rows
+                FROM  pg_stat_statements
+                WHERE mean_exec_time >= %s
+                ORDER BY mean_exec_time DESC
+                LIMIT %s
+            """, (min_duration_ms, limit))
+            return [dict(r) for r in cur.fetchall()]
+    finally:
+        conn.close()
+
+
+def check_db_health(instance: Dict) -> Dict[str, Any]:
+    """Quick health summary: version, uptime, connections, replication lag."""
+    conn = _get_conn(instance)
+    try:
+        with conn.cursor() as cur:
+            cur.execute("SELECT version()")
+            version = cur.fetchone()["version"]
+
+            cur.execute("SELECT pg_postmaster_start_time()")
+            start_time = cur.fetchone()["pg_postmaster_start_time"]
+
+            cur.execute("""
+                SELECT count(*) AS total,
+                       sum(CASE WHEN state = 'active' THEN 1 ELSE 0 END)  AS active,
+                       sum(CASE WHEN state = 'idle'   THEN 1 ELSE 0 END)  AS idle,
+                       max(EXTRACT(EPOCH FROM (now() - query_start)))      AS longest_query_secs
+                FROM   pg_stat_activity
+                WHERE  pid <> pg_backend_pid()
+            """)
+            conn_row = dict(cur.fetchone())
+
+            cur.execute("SHOW max_connections")
+            max_conn = int(cur.fetchone()["max_connections"])
+
+            # Replication lag (returns None if not a replica)
+            cur.execute("""
+                SELECT CASE WHEN pg_is_in_recovery()
+                            THEN EXTRACT(EPOCH FROM (now() - pg_last_xact_replay_timestamp()))
+                            ELSE NULL
+                       END AS replication_lag_secs
+            """)
+            repl = cur.fetchone()
+
+            return {
+                "version": version,
+                "start_time": str(start_time),
+                "max_connections": max_conn,
+                "connections": conn_row,
+                "replication_lag_secs": repl["replication_lag_secs"],
+                "is_replica": repl["replication_lag_secs"] is not None,
+            }
+    finally:
+        conn.close()

--- a/pkg/agents/postgres/postgres_connector.py
+++ b/pkg/agents/postgres/postgres_connector.py
@@ -28,7 +28,14 @@ def _load_config() -> List[Dict]:
 
 
 def _get_conn(instance: Dict) -> psycopg2.extensions.connection:
-    """Open a psycopg2 connection for a given config instance."""
+    """
+    Open a read-only psycopg2 connection for a given config instance.
+
+    ``default_transaction_read_only=on`` is enforced at the session level so
+    that even CTEs containing DML (e.g. ``WITH x AS (DELETE ...) SELECT ...``)
+    are rejected by PostgreSQL — not just by the client-side prefix check in
+    ``execute_query``.
+    """
     return psycopg2.connect(
         host=instance.get("host", "localhost"),
         port=instance.get("port", 5432),
@@ -37,6 +44,7 @@ def _get_conn(instance: Dict) -> psycopg2.extensions.connection:
         dbname=instance.get("dbname", "postgres"),
         sslmode=instance.get("sslmode", "disable"),
         cursor_factory=psycopg2.extras.RealDictCursor,
+        options="-c default_transaction_read_only=on",
     )
 
 
@@ -168,11 +176,20 @@ def execute_query(instance: Dict, sql: str, limit: int = 100) -> Tuple[List[Dict
 
 
 def explain_query(instance: Dict, sql: str) -> List[str]:
-    """Return EXPLAIN ANALYZE output for a query."""
+    """
+    Return EXPLAIN (ANALYZE, BUFFERS) output for a SELECT or WITH query.
+
+    Only SELECT/WITH queries are accepted — EXPLAIN ANALYZE actually executes
+    the statement, so we validate the SQL before running it.
+    """
+    normalized = sql.strip().upper()
+    if not (normalized.startswith("SELECT") or normalized.startswith("WITH")):
+        raise ValueError("Only SELECT / WITH queries are allowed in explain_query.")
+
     conn = _get_conn(instance)
     try:
         with conn.cursor() as cur:
-            cur.execute(f"EXPLAIN ANALYZE {sql}")
+            cur.execute(f"EXPLAIN (ANALYZE, BUFFERS, FORMAT TEXT) {sql}")
             return [row[0] for row in cur.fetchall()]
     finally:
         conn.close()
@@ -239,28 +256,39 @@ def get_slow_queries(instance: Dict, min_duration_ms: float = 100.0, limit: int 
     """
     Return top slow queries from pg_stat_statements.
     Requires the pg_stat_statements extension to be enabled.
+
+    Handles the column rename introduced in PostgreSQL 13:
+      - PostgreSQL ≤12: total_time / mean_time / stddev_time
+      - PostgreSQL ≥13: total_exec_time / mean_exec_time / stddev_exec_time
     """
     conn = _get_conn(instance)
     try:
         with conn.cursor() as cur:
             # Check extension exists first
-            cur.execute("""
-                SELECT 1 FROM pg_extension WHERE extname = 'pg_stat_statements'
-            """)
+            cur.execute("SELECT 1 FROM pg_extension WHERE extname = 'pg_stat_statements'")
             if not cur.fetchone():
                 return [{"error": "pg_stat_statements extension is not enabled on this server."}]
 
-            cur.execute("""
+            # Detect PostgreSQL version to handle column name change in pg13
+            cur.execute("SELECT current_setting('server_version_num')::int AS ver")
+            pg_ver = cur.fetchone()["ver"]
+
+            if pg_ver >= 130000:
+                total_col, mean_col, stddev_col = "total_exec_time", "mean_exec_time", "stddev_exec_time"
+            else:
+                total_col, mean_col, stddev_col = "total_time", "mean_time", "stddev_time"
+
+            cur.execute(f"""
                 SELECT
-                    left(query, 200)                             AS query_preview,
+                    left(query, 200)                               AS query_preview,
                     calls,
-                    round(total_exec_time::numeric, 2)           AS total_exec_ms,
-                    round(mean_exec_time::numeric,  2)           AS mean_exec_ms,
-                    round(stddev_exec_time::numeric, 2)          AS stddev_exec_ms,
+                    round({total_col}::numeric,  2)                AS total_exec_ms,
+                    round({mean_col}::numeric,   2)                AS mean_exec_ms,
+                    round({stddev_col}::numeric, 2)                AS stddev_exec_ms,
                     rows
                 FROM  pg_stat_statements
-                WHERE mean_exec_time >= %s
-                ORDER BY mean_exec_time DESC
+                WHERE {mean_col} >= %s
+                ORDER BY {mean_col} DESC
                 LIMIT %s
             """, (min_duration_ms, limit))
             return [dict(r) for r in cur.fetchall()]

--- a/pkg/agents/postgres/requirements.txt
+++ b/pkg/agents/postgres/requirements.txt
@@ -1,0 +1,3 @@
+fastmcp
+psycopg2-binary
+pyyaml

--- a/pkg/agents/postgres/requirements.txt
+++ b/pkg/agents/postgres/requirements.txt
@@ -1,3 +1,4 @@
-fastmcp
-psycopg2-binary
-pyyaml
+# Match versions from the project root requirements.txt where applicable.
+fastmcp==0.2.0
+psycopg2-binary>=2.9,<3.0
+PyYAML==6.0.2

--- a/pkg/agents/postgres/server.py
+++ b/pkg/agents/postgres/server.py
@@ -1,0 +1,300 @@
+# server.py — PostgreSQL MCP Server for SODA Contexture
+#
+# Implements the same FastMCP @app.tool() pattern as pkg/mcp/server.py.
+# Connects to PostgreSQL instances defined in config/postgres_config.yaml.
+#
+# Inspired by open-source PostgreSQL MCP servers:
+#   - crystaldba/postgres-mcp  (https://github.com/crystaldba/postgres-mcp)
+#   - modelcontextprotocol/servers/src/postgres  (https://github.com/modelcontextprotocol/servers)
+#
+# Run:
+#   cd pkg/agents/postgres
+#   uvicorn server:app --port 8003   # HTTP/SSE transport (for client_dynamic.py)
+#   python server.py                 # stdio transport
+
+import os
+import yaml
+from datetime import datetime
+from typing import Any, Dict, List, Optional
+
+from fastmcp import FastMCP
+from postgres_connector import (
+    get_all_instances,
+    list_databases,
+    list_schemas,
+    list_tables,
+    describe_table,
+    execute_query,
+    explain_query,
+    get_table_stats,
+    get_db_stats,
+    get_slow_queries,
+    check_db_health,
+)
+
+app = FastMCP("PostgreSQL MCP Server")
+
+# ── lazy-load instances ───────────────────────────────────────────────────────
+
+def _instances() -> List[Dict]:
+    try:
+        return get_all_instances()
+    except FileNotFoundError as e:
+        print(f"[postgres-mcp] WARNING: {e}")
+        return []
+
+
+# ── tools ─────────────────────────────────────────────────────────────────────
+
+@app.tool()
+def pg_list_databases() -> Dict[str, Any]:
+    """
+    List all non-template PostgreSQL databases across configured instances.
+    Returns name, owner, encoding, collation, and size for each database.
+    Useful for understanding what databases exist and their storage footprint.
+    """
+    all_results = {}
+    for inst in _instances():
+        name = inst.get("name", "default")
+        try:
+            all_results[name] = list_databases(inst)
+        except Exception as e:
+            all_results[name] = {"error": str(e)}
+
+    return {
+        "databases_per_instance": all_results,
+        "timestamp": datetime.now().isoformat(),
+    }
+
+
+@app.tool()
+def pg_list_schemas() -> Dict[str, Any]:
+    """
+    List all user-visible schemas in the connected database (excludes system schemas).
+    Schemas partition a database into logical namespaces — knowing them is the
+    first step to understanding data organisation.
+    """
+    all_results = {}
+    for inst in _instances():
+        name = inst.get("name", "default")
+        try:
+            all_results[name] = list_schemas(inst)
+        except Exception as e:
+            all_results[name] = {"error": str(e)}
+
+    return {
+        "schemas_per_instance": all_results,
+        "timestamp": datetime.now().isoformat(),
+    }
+
+
+@app.tool()
+def pg_list_tables(schema: str = "public") -> Dict[str, Any]:
+    """
+    List all tables and views in the given schema.
+    Returns table_name and table_type (BASE TABLE or VIEW) for each entry.
+
+    Args:
+        schema: Schema name to query (default: 'public').
+    """
+    all_results = {}
+    for inst in _instances():
+        name = inst.get("name", "default")
+        try:
+            all_results[name] = list_tables(inst, schema)
+        except Exception as e:
+            all_results[name] = {"error": str(e)}
+
+    return {
+        "schema": schema,
+        "tables_per_instance": all_results,
+        "timestamp": datetime.now().isoformat(),
+    }
+
+
+@app.tool()
+def pg_describe_table(schema: str, table: str) -> Dict[str, Any]:
+    """
+    Return the full structure of a table: columns (name, type, nullability, default),
+    primary keys, and indexes. Essential for understanding data shape before querying.
+
+    Args:
+        schema: Schema name (e.g. 'public').
+        table:  Table name.
+    """
+    all_results = {}
+    for inst in _instances():
+        name = inst.get("name", "default")
+        try:
+            all_results[name] = describe_table(inst, schema, table)
+        except Exception as e:
+            all_results[name] = {"error": str(e)}
+
+    return {
+        "description_per_instance": all_results,
+        "timestamp": datetime.now().isoformat(),
+    }
+
+
+@app.tool()
+def pg_execute_query(sql: str, limit: int = 100) -> Dict[str, Any]:
+    """
+    Execute a read-only SELECT (or WITH) query and return results as rows.
+    Non-SELECT statements are rejected — use pg_execute_statement for writes.
+
+    Args:
+        sql:   A SELECT or WITH SQL query.
+        limit: Maximum number of rows to return (default: 100).
+    """
+    all_results = {}
+    for inst in _instances():
+        name = inst.get("name", "default")
+        try:
+            rows, cols = execute_query(inst, sql, limit)
+            all_results[name] = {
+                "columns":   cols,
+                "rows":      rows,
+                "row_count": len(rows),
+            }
+        except Exception as e:
+            all_results[name] = {"error": str(e)}
+
+    return {
+        "query":              sql,
+        "results_per_instance": all_results,
+        "timestamp":          datetime.now().isoformat(),
+    }
+
+
+@app.tool()
+def pg_explain_query(sql: str) -> Dict[str, Any]:
+    """
+    Run EXPLAIN ANALYZE on a SQL query and return the execution plan.
+    Use this to understand query performance and identify bottlenecks
+    before suggesting index or schema changes.
+
+    Args:
+        sql: The SQL query to explain (SELECT recommended).
+    """
+    all_results = {}
+    for inst in _instances():
+        name = inst.get("name", "default")
+        try:
+            all_results[name] = explain_query(inst, sql)
+        except Exception as e:
+            all_results[name] = {"error": str(e)}
+
+    return {
+        "query":             sql,
+        "plan_per_instance": all_results,
+        "timestamp":         datetime.now().isoformat(),
+    }
+
+
+@app.tool()
+def pg_get_table_stats(schema: str, table: str) -> Dict[str, Any]:
+    """
+    Return runtime statistics for a table from pg_stat_user_tables:
+    live rows, dead rows, total size, index size, last vacuum / analyze timestamps.
+    Useful for detecting bloat or stale statistics.
+
+    Args:
+        schema: Schema name.
+        table:  Table name.
+    """
+    all_results = {}
+    for inst in _instances():
+        name = inst.get("name", "default")
+        try:
+            stats = get_table_stats(inst, schema, table)
+            all_results[name] = (
+                stats if stats
+                else {"error": f"Table {schema}.{table} not found in pg_stat_user_tables"}
+            )
+        except Exception as e:
+            all_results[name] = {"error": str(e)}
+
+    return {
+        "schema":             schema,
+        "table":              table,
+        "stats_per_instance": all_results,
+        "timestamp":          datetime.now().isoformat(),
+    }
+
+
+@app.tool()
+def pg_get_db_stats() -> Dict[str, Any]:
+    """
+    Return database-level statistics from pg_stat_database:
+    active connections, commits, rollbacks, cache hit ratio, rows inserted/updated/deleted,
+    and deadlock count. Provides a quick operational snapshot of database health.
+    """
+    all_results = {}
+    for inst in _instances():
+        name = inst.get("name", "default")
+        try:
+            all_results[name] = get_db_stats(inst)
+        except Exception as e:
+            all_results[name] = {"error": str(e)}
+
+    return {
+        "db_stats_per_instance": all_results,
+        "timestamp": datetime.now().isoformat(),
+    }
+
+
+@app.tool()
+def pg_get_slow_queries(
+    min_duration_ms: float = 100.0,
+    limit: int = 10,
+) -> Dict[str, Any]:
+    """
+    Return the top slow queries from pg_stat_statements (requires the extension).
+    Shows query preview, call count, total/mean/stddev execution time, and rows returned.
+    Use this to identify performance hotspots.
+
+    Args:
+        min_duration_ms: Minimum mean execution time in milliseconds (default: 100).
+        limit:           Maximum number of queries to return (default: 10).
+    """
+    all_results = {}
+    for inst in _instances():
+        name = inst.get("name", "default")
+        try:
+            all_results[name] = get_slow_queries(inst, min_duration_ms, limit)
+        except Exception as e:
+            all_results[name] = {"error": str(e)}
+
+    return {
+        "min_duration_ms":        min_duration_ms,
+        "slow_queries_per_instance": all_results,
+        "timestamp":              datetime.now().isoformat(),
+    }
+
+
+@app.tool()
+def pg_check_db_health() -> Dict[str, Any]:
+    """
+    Return a health summary for each configured PostgreSQL instance:
+    version, server start time, max/active/idle connections, longest running query,
+    and replication lag (if this is a replica).
+    Use this as the first tool to call when diagnosing database issues.
+    """
+    all_results = {}
+    for inst in _instances():
+        name = inst.get("name", "default")
+        try:
+            all_results[name] = check_db_health(inst)
+        except Exception as e:
+            all_results[name] = {"error": str(e)}
+
+    return {
+        "health_per_instance": all_results,
+        "timestamp": datetime.now().isoformat(),
+    }
+
+
+# ── entry point ───────────────────────────────────────────────────────────────
+
+if __name__ == "__main__":
+    app.run()

--- a/pkg/agents/postgres/server.py
+++ b/pkg/agents/postgres/server.py
@@ -7,10 +7,10 @@
 #   - crystaldba/postgres-mcp  (https://github.com/crystaldba/postgres-mcp)
 #   - modelcontextprotocol/servers/src/postgres  (https://github.com/modelcontextprotocol/servers)
 #
-# Run:
-#   cd pkg/agents/postgres
-#   uvicorn server:app --port 8003   # HTTP/SSE transport (for client_dynamic.py)
-#   python server.py                 # stdio transport
+# Run (always from the pkg/agents/postgres/ directory):
+#   python server.py                          # stdio transport (default)
+#   python server.py --transport sse          # SSE/HTTP on port 8003
+#   python server.py --transport sse --port 9000  # custom port
 
 import os
 import yaml
@@ -297,4 +297,24 @@ def pg_check_db_health() -> Dict[str, Any]:
 # ── entry point ───────────────────────────────────────────────────────────────
 
 if __name__ == "__main__":
-    app.run()
+    import argparse
+
+    parser = argparse.ArgumentParser(description="PostgreSQL MCP Server for SODA Contexture")
+    parser.add_argument(
+        "--transport",
+        choices=["stdio", "sse"],
+        default="stdio",
+        help="MCP transport type (default: stdio)",
+    )
+    parser.add_argument(
+        "--port",
+        type=int,
+        default=8003,
+        help="Port for SSE transport (default: 8003)",
+    )
+    args = parser.parse_args()
+
+    if args.transport == "sse":
+        app.run(transport="sse", port=args.port)
+    else:
+        app.run()

--- a/pkg/agents/postgres/test_connection.py
+++ b/pkg/agents/postgres/test_connection.py
@@ -1,0 +1,97 @@
+#!/usr/bin/env python3
+"""
+Quick connectivity test for the PostgreSQL MCP agent.
+
+Run from this directory:
+    cd pkg/agents/postgres
+    python test_connection.py
+
+Reads connection settings from config/postgres_config.yaml.
+Verifies that:
+  1. The config file is found and parses correctly.
+  2. Each configured instance accepts a connection.
+  3. list_databases() and list_schemas() return data without errors.
+"""
+import sys
+import os
+
+# Ensure imports resolve regardless of working directory
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+from postgres_connector import get_all_instances, _get_conn, list_databases, list_schemas
+
+
+def _hr():
+    print("-" * 50)
+
+
+def main():
+    # ── 1. Config loading ────────────────────────────────
+    print("Loading postgres_config.yaml...")
+    try:
+        instances = get_all_instances()
+    except FileNotFoundError as e:
+        print(f"ERROR: {e}")
+        print(
+            "\nMake sure config/postgres_config.yaml exists at the repo root.\n"
+            "Copy the template if needed:\n"
+            "  cp config/postgres_config.yaml.example config/postgres_config.yaml"
+        )
+        sys.exit(1)
+
+    if not instances:
+        print("ERROR: No instances found in postgres_config.yaml. Add at least one entry under postgres_instances:")
+        sys.exit(1)
+
+    print(f"Found {len(instances)} instance(s): {[i.get('name') for i in instances]}\n")
+
+    # ── 2. Per-instance checks ───────────────────────────
+    all_ok = True
+    for inst in instances:
+        name = inst.get("name", "default")
+        _hr()
+        print(f"Instance : {name}")
+        print(f"Host     : {inst.get('host')}:{inst.get('port', 5432)}")
+        print(f"Database : {inst.get('dbname')}")
+        print(f"User     : {inst.get('user')}")
+
+        # Connection test
+        try:
+            conn = _get_conn(inst)
+            conn.close()
+            print("Connection: OK")
+        except Exception as exc:
+            print(f"Connection: FAILED — {exc}")
+            all_ok = False
+            continue
+
+        # list_databases
+        try:
+            dbs = list_databases(inst)
+            print(f"Databases ({len(dbs)}):")
+            for db in dbs:
+                print(f"  - {db['name']}  [{db['encoding']}]  {db['size']}")
+        except Exception as exc:
+            print(f"list_databases: FAILED — {exc}")
+            all_ok = False
+
+        # list_schemas
+        try:
+            schemas = list_schemas(inst)
+            print(f"Schemas   : {', '.join(schemas) if schemas else '(none)'}")
+        except Exception as exc:
+            print(f"list_schemas: FAILED — {exc}")
+            all_ok = False
+
+    # ── 3. Summary ───────────────────────────────────────
+    _hr()
+    if all_ok:
+        print("All instances OK.")
+        sys.exit(0)
+    else:
+        print("One or more instances had errors (see above).")
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/pkg/agents/postgres/tool_registry.py
+++ b/pkg/agents/postgres/tool_registry.py
@@ -1,0 +1,25 @@
+from mcp_tools import (
+    list_databases_tool,
+    list_schemas_tool,
+    list_tables_tool,
+    describe_table_tool,
+    execute_query_tool,
+    explain_query_tool,
+    get_table_stats_tool,
+    get_db_stats_tool,
+    get_slow_queries_tool,
+    check_db_health_tool,
+)
+
+TOOLS = {
+    "list_databases":  list_databases_tool,
+    "list_schemas":    list_schemas_tool,
+    "list_tables":     list_tables_tool,
+    "describe_table":  describe_table_tool,
+    "execute_query":   execute_query_tool,
+    "explain_query":   explain_query_tool,
+    "get_table_stats": get_table_stats_tool,
+    "get_db_stats":    get_db_stats_tool,
+    "get_slow_queries": get_slow_queries_tool,
+    "check_db_health": check_db_health_tool,
+}


### PR DESCRIPTION

Added pkg/agents/postgres as a new data connector for SODA Contexture.

- server.py: FastMCP server with 10 @app.tool() definitions following
  the same pattern as pkg/mcp/server.py (Prometheus MCP server)
- postgres_connector.py: psycopg2-based query helpers (list databases,
  schemas, tables, describe table, execute query, explain query,
  table/db stats, slow queries, health check)
- mcp_tools.py: tool wrapper functions callable without the server
- tool_registry.py: TOOLS dict, mirrors mongodb/tool_registry.py
- agent.py: keyword-based NL query router, mirrors mongodb/agent.py
- requirements.txt: fastmcp, psycopg2-binary, pyyaml
- config/postgres_config.yaml: connection config at project config root,
  same level as prometheus_config.yaml

Tool design follows patterns from crystaldba/postgres-mcp open-source
PostgreSQL MCP server. Runs on port 8003 alongside the Prometheus MCP
server (port 8001), plugging into the existing Ollama → FastMCP pipeline.
**What type of PR is this?**
> /kind new feature
> /kind design
> /kind documentation
> /kind enhancement

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!--
*Please provide the issues number or link.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #25 

**Test Report Added?**:
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespace from that line:
> /kind NOT TESTED

**Test Report**:
<!--
*Please provide the test report link (public accessible, screen shot or copy paste the test report, 
or add the testing details.
-->

**Special notes for your reviewer**:
