### PR TITLE
Add S3 validation test report

### DIFF
--- a/pkg/agents/s3/test-report.md
+++ b/pkg/agents/s3/test-report.md
@@ -1,0 +1,176 @@
+\# S3 Agent Validation Test Report
+
+
+
+\## Objective
+
+
+
+Validate the S3 agent using MinIO by populating sample data and verifying S3 integration and MCP tool registration.
+
+
+
+\## Environment
+
+
+
+| Component        | Details                         |
+
+| ---------------- | ------------------------------- |
+
+| Project          | SODA Contexture - pkg/agents/s3 |
+
+| Storage Backend  | MinIO                           |
+
+| AI Provider      | Gemini                          |
+
+| MCP Server       | AWS MCP Server                  |
+
+| Operating System | Windows                         |
+
+
+
+\## Validation Steps
+
+
+
+\### 1. MinIO Setup
+
+
+
+\* Installed MinIO locally.
+
+\* Started MinIO server.
+
+\* Verified API (`localhost:9000`) and Console (`localhost:9001`).
+
+
+
+\*\*Result:\*\* PASS
+
+
+
+\### 2. Bucket Creation
+
+
+
+Created bucket:
+
+
+
+`test-bucket`
+
+
+
+\*\*Result:\*\* PASS
+
+
+
+\### 3. Data Population
+
+
+
+Uploaded sample files:
+
+
+
+\* employees.csv
+
+\* products.json
+
+\* users.txt
+
+
+
+\*\*Result:\*\* PASS
+
+
+
+\### 4. MCP Server Validation
+
+
+
+Started the MCP server:
+
+
+
+```bash
+
+go run .\\cmd\\server\\main.go
+
+```
+
+
+
+Verified:
+
+
+
+\* AWS connectivity
+
+\* MCP server initialization
+
+\* MCP server startup
+
+
+
+\*\*Result:\*\* PASS
+
+
+
+\### 5. S3 Tool Registration
+
+
+
+Verified the following tools:
+
+
+
+\* create-s3-bucket
+
+\* list-s3-buckets
+
+\* list-s3-objects
+
+\* analyze-data-landscape
+
+\* describe-bucket-context
+
+
+
+\*\*Result:\*\* PASS
+
+
+
+\## Summary
+
+
+
+| Test Case          | Result |
+
+| ------------------ | ------ |
+
+| Start MinIO        | PASS   |
+
+| Create Bucket      | PASS   |
+
+| Upload Sample Data | PASS   |
+
+| Start MCP Server   | PASS   |
+
+| Register S3 Tools  | PASS   |
+
+
+
+\## Notes
+
+
+
+MinIO was successfully used as an S3-compatible backend. Data population and MCP server validation were completed successfully.
+
+
+
+Interactive natural-language query execution was not validated because the current repository copy does not expose the client/Web UI layer.
+
+
+


### PR DESCRIPTION
## Summary

Added `pkg/agents/s3/test-report.md` containing the S3 validation steps and results.

## Validation Performed

- Started MinIO locally as an S3-compatible backend
- Created a test bucket
- Populated sample datasets (CSV, JSON, TXT)
- Started the MCP server
- Verified S3-related tool registration

## Verified Tools

- create-s3-bucket
- list-s3-buckets
- list-s3-objects
- analyze-data-landscape
- describe-bucket-context

## Notes

Interactive natural-language query execution was not validated because the current repository copy does not expose the client/Web UI layer. Backend validation was completed successfully using MinIO and MCP server verification.